### PR TITLE
fix: better reconnecting

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-sparse-arrays */
-
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [

--- a/src/providers/ble/index.tsx
+++ b/src/providers/ble/index.tsx
@@ -1,65 +1,25 @@
 import { BLE_MOCK } from '@euc-tricorder/core';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { BleManager, BleRestoredState, State } from 'react-native-ble-plx';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { BleManager, State } from 'react-native-ble-plx';
 
 import { BleManagerMock } from './mock';
 
 export type BleAPI = {
   manager: BleManager | null;
   state: State;
-  registerRestoreStateListener: (listener: Listener) => () => void;
 };
 
 const BleContext = React.createContext<BleAPI>({
   manager: null,
   state: 'Unknown' as State,
-  registerRestoreStateListener: () => () => undefined,
 });
-
-type Listener = (restoredState: BleRestoredState) => void;
 
 export const useBle = () => useContext(BleContext);
 
 export const BleProvider: React.FC = ({ children }) => {
-  const listeners = useRef<Array<Listener | undefined>>([]);
-
   const bleManagerRef = useRef<BleManager>(
-    BLE_MOCK
-      ? ((BleManagerMock() as unknown) as BleManager)
-      : new BleManager({
-          restoreStateIdentifier: 'org.jukben.euctricorder',
-          restoreStateFunction: (restoredState) => {
-            if (!restoredState) {
-              return;
-            }
-
-            console.log('BleProvider has restored state', restoredState);
-            listeners.current.forEach((listener) => {
-              listener && listener(restoredState);
-            });
-          },
-        }),
+    BLE_MOCK ? ((BleManagerMock() as unknown) as BleManager) : new BleManager(),
   );
-
-  /**
-   * TODO rewrite this to reuse deleted ids.
-   * Maybe it would be good to create some abstraction for it since I use
-   * it on multiple places.
-   */
-  const registerRestoreStateListener = useCallback((listener: Listener) => {
-    const id = listeners.current.push(listener) - 1;
-
-    return () => {
-      delete listeners.current[id];
-    };
-  }, []);
 
   const [state, setState] = useState<State>('Unknown' as State);
 
@@ -75,9 +35,8 @@ export const BleProvider: React.FC = ({ children }) => {
     () => ({
       manager: bleManagerRef.current,
       state,
-      registerRestoreStateListener,
     }),
-    [registerRestoreStateListener, state],
+    [state],
   );
 
   return <BleContext.Provider value={api}>{children}</BleContext.Provider>;

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -3,7 +3,7 @@ import { useDeviceScan } from '@euc-tricorder/core/shared';
 import { CustomNavigatorProps } from '@euc-tricorder/types';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { Device } from 'react-native-ble-plx';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
@@ -11,7 +11,6 @@ import {
   FlicClientProvider,
   PebbleClientProvider,
   useAdapter,
-  useBle,
 } from '../../providers';
 import { CrossroadNavigatorProps, Stack as CrossroadStack } from '../crossroad';
 import { DeviceScreen } from './device';
@@ -30,7 +29,6 @@ const Tab = createBottomTabNavigator<HomeStack>();
 
 export const Home = ({ route }: CrossroadNavigatorProps<'Home'>) => {
   const { setAdapter } = useAdapter();
-  const { registerRestoreStateListener } = useBle();
 
   const {
     params: { device },
@@ -74,25 +72,6 @@ export const Home = ({ route }: CrossroadNavigatorProps<'Home'>) => {
   useDeviceScan({
     onDeviceFound,
   });
-
-  useEffect(() => {
-    const unsubscribe = registerRestoreStateListener((restoredState) => {
-      console.log('...restoring connection...');
-
-      const bleDevice = restoredState.connectedPeripherals.find(
-        ({ id }) => id === device.id,
-      );
-
-      if (!bleDevice) {
-        return;
-      }
-
-      connectToDevice(bleDevice);
-      console.log('...connected!');
-    });
-
-    return unsubscribe;
-  }, [device.id, connectToDevice, registerRestoreStateListener]);
 
   return (
     <PebbleClientProvider>


### PR DESCRIPTION
- Removed `restoreStateFunction` because I have a feeling that its implementation is buggy, so simpler code = safer code. 

- `startDeviceScan` works only in foreground so I had to add check for that as well.

- `useDeviceScan` now consumes also `adapter` in order to keep reconnecting loop in place